### PR TITLE
Add ReadlyIt demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# readlyit
+# ReadlyIt
 
-A new Flutter project.
+ReadlyIt is a minimal **Read It Later** application built with Flutter.
+It supports Android, iOS, macOS, Linux and Windows platforms.
 
-## Getting Started
+## Features
 
-This project is a starting point for a Flutter application.
+* Import links from the system share menu using **receive_sharing_intent**.
+* Import Pocket export files (`.html`) through the app bar action.
+* Cross platform data storage using Hive with optional iCloud sync on iOS.
+* Multi language user interface (English, 中文 and 日本語).
+* Appearance settings for theme mode and font size.
 
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+This project is only a basic demo and can be extended with more
+functionality such as background sync or advanced parsing.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It supports Android, iOS, macOS, Linux and Windows platforms.
 * Import Pocket export files (`.html`) through the app bar action.
 * Riverpod based state management with Hive persistence and optional iCloud sync.
 * Multi language user interface (English, 中文 and 日本語).
-* Appearance settings for theme mode, font size and default reading mode.
+* Appearance settings with light/dark mode toggle, font size and default reading mode.
 * Built in web view with toggleable reading mode.
 * Modern Material 3 UI with card-based reading list.
 * Modular storage layer with in-memory implementation for unit tests.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ It supports Android, iOS, macOS, Linux and Windows platforms.
 
 * Import links from the system share menu using **receive_sharing_intent**.
 * Import Pocket export files (`.html`) through the app bar action.
-* Cross platform data storage using Hive with optional iCloud sync on iOS.
+* Riverpod based state management with Hive persistence and optional iCloud sync.
 * Multi language user interface (English, 中文 and 日本語).
-* Appearance settings for theme mode and font size.
+* Appearance settings for theme mode, font size and default reading mode.
+* Built in web view with toggleable reading mode.
 
 This project is only a basic demo and can be extended with more
 functionality such as background sync or advanced parsing.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It supports Android, iOS, macOS, Linux and Windows platforms.
 * Multi language user interface (English, 中文 and 日本語).
 * Appearance settings for theme mode, font size and default reading mode.
 * Built in web view with toggleable reading mode.
+* Modern Material 3 UI with card-based reading list.
 
 This project is only a basic demo and can be extended with more
 functionality such as background sync or advanced parsing.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ It supports Android, iOS, macOS, Linux and Windows platforms.
 * Appearance settings for theme mode, font size and default reading mode.
 * Built in web view with toggleable reading mode.
 * Modern Material 3 UI with card-based reading list.
+* Modular storage layer with in-memory implementation for unit tests.
 
 This project is only a basic demo and can be extended with more
 functionality such as background sync or advanced parsing.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+flutter test
+```
+
+The project includes model and provider tests using an in-memory
+storage service for fast execution.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13,6 +13,7 @@ class AppLocalizations {
       'font_family': 'Font',
       'theme': 'Theme',
       'language': 'Language',
+      'reading_mode': 'Reading Mode',
     },
     'zh': {
       'app_title': '稍后阅读',
@@ -22,6 +23,7 @@ class AppLocalizations {
       'font_family': '字体',
       'theme': '主题',
       'language': '语言',
+      'reading_mode': '阅读模式',
     },
     'ja': {
       'app_title': '後で読む',
@@ -31,6 +33,7 @@ class AppLocalizations {
       'font_family': 'フォント',
       'theme': 'テーマ',
       'language': '言語',
+      'reading_mode': 'リーディングモード',
     },
   };
 
@@ -46,6 +49,7 @@ class AppLocalizations {
   String get fontFamily => _text('font_family');
   String get theme => _text('theme');
   String get language => _text('language');
+  String get readingMode => _text('reading_mode');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  AppLocalizations(this.locale);
+
+  static const _localizedValues = <String, Map<String, String>>{
+    'en': {
+      'app_title': 'Read It Later',
+      'settings': 'Settings',
+      'import_pocket': 'Import Pocket File',
+      'font_size': 'Font Size',
+      'font_family': 'Font',
+      'theme': 'Theme',
+      'language': 'Language',
+    },
+    'zh': {
+      'app_title': '稍后阅读',
+      'settings': '设置',
+      'import_pocket': '导入 Pocket 文件',
+      'font_size': '字体大小',
+      'font_family': '字体',
+      'theme': '主题',
+      'language': '语言',
+    },
+    'ja': {
+      'app_title': '後で読む',
+      'settings': '設定',
+      'import_pocket': 'Pocket ファイルをインポート',
+      'font_size': '文字サイズ',
+      'font_family': 'フォント',
+      'theme': 'テーマ',
+      'language': '言語',
+    },
+  };
+
+  String _text(String key) {
+    return _localizedValues[locale.languageCode]?[key] ??
+        _localizedValues['en']![key]!;
+  }
+
+  String get appTitle => _text('app_title');
+  String get settings => _text('settings');
+  String get importPocket => _text('import_pocket');
+  String get fontSize => _text('font_size');
+  String get fontFamily => _text('font_family');
+  String get theme => _text('theme');
+  String get language => _text('language');
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return ['en', 'zh', 'ja'].contains(locale.languageCode);
+  }
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14,6 +14,7 @@ class AppLocalizations {
       'theme': 'Theme',
       'language': 'Language',
       'reading_mode': 'Reading Mode',
+      'ok': 'OK',
     },
     'zh': {
       'app_title': '稍后阅读',
@@ -24,6 +25,7 @@ class AppLocalizations {
       'theme': '主题',
       'language': '语言',
       'reading_mode': '阅读模式',
+      'ok': '确定',
     },
     'ja': {
       'app_title': '後で読む',
@@ -34,6 +36,7 @@ class AppLocalizations {
       'theme': 'テーマ',
       'language': '言語',
       'reading_mode': 'リーディングモード',
+      'ok': 'OK',
     },
   };
 
@@ -50,6 +53,7 @@ class AppLocalizations {
   String get theme => _text('theme');
   String get language => _text('language');
   String get readingMode => _text('reading_mode');
+  String get ok => _text('ok');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12,6 +12,7 @@ class AppLocalizations {
       'font_size': 'Font Size',
       'font_family': 'Font',
       'theme': 'Theme',
+      'dark_mode': 'Dark Mode',
       'language': 'Language',
       'reading_mode': 'Reading Mode',
       'ok': 'OK',
@@ -23,6 +24,7 @@ class AppLocalizations {
       'font_size': '字体大小',
       'font_family': '字体',
       'theme': '主题',
+      'dark_mode': '深色模式',
       'language': '语言',
       'reading_mode': '阅读模式',
       'ok': '确定',
@@ -34,6 +36,7 @@ class AppLocalizations {
       'font_size': '文字サイズ',
       'font_family': 'フォント',
       'theme': 'テーマ',
+      'dark_mode': 'ダークモード',
       'language': '言語',
       'reading_mode': 'リーディングモード',
       'ok': 'OK',
@@ -51,6 +54,7 @@ class AppLocalizations {
   String get fontSize => _text('font_size');
   String get fontFamily => _text('font_family');
   String get theme => _text('theme');
+  String get darkMode => _text('dark_mode');
   String get language => _text('language');
   String get readingMode => _text('reading_mode');
   String get ok => _text('ok');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,7 @@ import 'screens/settings_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final storage = await StorageService.create();
+  final storage = await HiveStorageService.create();
   runApp(
     ProviderScope(
       overrides: [storageProvider.overrideWithValue(storage)],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'l10n/app_localizations.dart';
 import 'providers/reading_list_provider.dart';
 import 'providers/settings_provider.dart';
+import 'providers/storage_provider.dart';
 import 'services/storage_service.dart';
 import 'screens/home_screen.dart';
 import 'screens/settings_screen.dart';
@@ -12,49 +13,43 @@ import 'screens/settings_screen.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final storage = await StorageService.create();
-  runApp(MyApp(storage: storage));
+  runApp(
+    ProviderScope(
+      overrides: [storageProvider.overrideWithValue(storage)],
+      child: const MyApp(),
+    ),
+  );
 }
 
-class MyApp extends StatelessWidget {
-  final StorageService storage;
-  const MyApp({super.key, required this.storage});
+class MyApp extends ConsumerWidget {
+  const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return MultiProvider(
-      providers: [
-        ChangeNotifierProvider(create: (_) => ReadingListProvider(storage)),
-        ChangeNotifierProvider(create: (_) => SettingsProvider(storage)),
-      ],
-      child: Consumer<SettingsProvider>(
-        builder: (context, settingsProvider, _) {
-          final settings = settingsProvider.settings;
-          return MaterialApp(
-            title: 'ReadlyIt',
-            themeMode: settings.themeMode,
-            theme: ThemeData(
-              textTheme:
-                  ThemeData.light().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
-            ),
-            darkTheme: ThemeData.dark().copyWith(
-              textTheme:
-                  ThemeData.dark().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
-            ),
-            locale: settings.locale,
-            localizationsDelegates: const [
-              AppLocalizations.delegate,
-              GlobalMaterialLocalizations.delegate,
-              GlobalWidgetsLocalizations.delegate,
-              GlobalCupertinoLocalizations.delegate,
-            ],
-            supportedLocales: const [Locale('en'), Locale('zh'), Locale('ja')],
-            routes: {
-              '/': (_) => const HomeScreen(),
-              '/settings': (_) => const SettingsScreen(),
-            },
-          );
-        },
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(settingsProvider);
+    return MaterialApp(
+      title: 'ReadlyIt',
+      themeMode: settings.themeMode,
+      theme: ThemeData(
+        textTheme:
+            ThemeData.light().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
       ),
+      darkTheme: ThemeData.dark().copyWith(
+        textTheme:
+            ThemeData.dark().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
+      ),
+      locale: settings.locale,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en'), Locale('zh'), Locale('ja')],
+      routes: {
+        '/': (_) => const HomeScreen(),
+        '/settings': (_) => const SettingsScreen(),
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,16 +27,22 @@ class MyApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(settingsProvider);
+    final baseTextTheme = ThemeData.light().textTheme.apply(
+          fontSizeFactor: settings.fontSize / 14,
+          fontFamily: settings.fontFamily == 'System' ? null : settings.fontFamily,
+        );
     return MaterialApp(
       title: 'ReadlyIt',
       themeMode: settings.themeMode,
       theme: ThemeData(
-        textTheme:
-            ThemeData.light().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
+        useMaterial3: true,
+        colorSchemeSeed: Colors.teal,
+        textTheme: baseTextTheme,
       ),
       darkTheme: ThemeData.dark().copyWith(
-        textTheme:
-            ThemeData.dark().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
+        useMaterial3: true,
+        colorSchemeSeed: Colors.teal,
+        textTheme: baseTextTheme,
       ),
       locale: settings.locale,
       localizationsDelegates: const [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,60 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
 
-void main() {
-  runApp(const MyApp());
+import 'l10n/app_localizations.dart';
+import 'providers/reading_list_provider.dart';
+import 'providers/settings_provider.dart';
+import 'services/storage_service.dart';
+import 'screens/home_screen.dart';
+import 'screens/settings_screen.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final storage = await StorageService.create();
+  runApp(MyApp(storage: storage));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+  final StorageService storage;
+  const MyApp({super.key, required this.storage});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => ReadingListProvider(storage)),
+        ChangeNotifierProvider(create: (_) => SettingsProvider(storage)),
+      ],
+      child: Consumer<SettingsProvider>(
+        builder: (context, settingsProvider, _) {
+          final settings = settingsProvider.settings;
+          return MaterialApp(
+            title: 'ReadlyIt',
+            themeMode: settings.themeMode,
+            theme: ThemeData(
+              textTheme:
+                  ThemeData.light().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
             ),
-          ],
-        ),
+            darkTheme: ThemeData.dark().copyWith(
+              textTheme:
+                  ThemeData.dark().textTheme.apply(fontSizeFactor: settings.fontSize / 14),
+            ),
+            locale: settings.locale,
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: const [Locale('en'), Locale('zh'), Locale('ja')],
+            routes: {
+              '/': (_) => const HomeScreen(),
+              '/settings': (_) => const SettingsScreen(),
+            },
+          );
+        },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/models/reading_item.dart
+++ b/lib/models/reading_item.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+class ReadingItem {
+  final String url;
+  final String? title;
+  final DateTime added;
+
+  ReadingItem({required this.url, this.title, DateTime? added})
+      : added = added ?? DateTime.now();
+
+  Map<String, dynamic> toMap() => {
+        'url': url,
+        'title': title,
+        'added': added.toIso8601String(),
+      };
+
+  factory ReadingItem.fromMap(Map<String, dynamic> map) => ReadingItem(
+        url: map['url'] as String,
+        title: map['title'] as String?,
+        added: DateTime.parse(map['added'] as String),
+      );
+
+  String toJson() => jsonEncode(toMap());
+
+  factory ReadingItem.fromJson(String source) =>
+      ReadingItem.fromMap(jsonDecode(source) as Map<String, dynamic>);
+}

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -6,12 +6,14 @@ class Settings {
   final double fontSize;
   final String fontFamily;
   final Locale locale;
+  final bool readingMode;
 
   Settings({
     this.themeMode = ThemeMode.system,
     this.fontSize = 14,
     this.fontFamily = 'System',
     this.locale = const Locale('en'),
+    this.readingMode = false,
   });
 
   Settings copyWith({
@@ -19,12 +21,14 @@ class Settings {
     double? fontSize,
     String? fontFamily,
     Locale? locale,
+    bool? readingMode,
   }) =>
       Settings(
         themeMode: themeMode ?? this.themeMode,
         fontSize: fontSize ?? this.fontSize,
         fontFamily: fontFamily ?? this.fontFamily,
         locale: locale ?? this.locale,
+        readingMode: readingMode ?? this.readingMode,
       );
 
   Map<String, dynamic> toMap() => {
@@ -32,6 +36,7 @@ class Settings {
         'fontSize': fontSize,
         'fontFamily': fontFamily,
         'locale': locale.toLanguageTag(),
+        'readingMode': readingMode,
       };
 
   factory Settings.fromMap(Map<String, dynamic> map) => Settings(
@@ -39,6 +44,7 @@ class Settings {
         fontSize: (map['fontSize'] as num).toDouble(),
         fontFamily: map['fontFamily'] as String,
         locale: Locale.fromSubtags(languageCode: map['locale'] as String),
+        readingMode: map['readingMode'] as bool? ?? false,
       );
 
   String toJson() => jsonEncode(toMap());

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+
+class Settings {
+  final ThemeMode themeMode;
+  final double fontSize;
+  final String fontFamily;
+  final Locale locale;
+
+  Settings({
+    this.themeMode = ThemeMode.system,
+    this.fontSize = 14,
+    this.fontFamily = 'System',
+    this.locale = const Locale('en'),
+  });
+
+  Settings copyWith({
+    ThemeMode? themeMode,
+    double? fontSize,
+    String? fontFamily,
+    Locale? locale,
+  }) =>
+      Settings(
+        themeMode: themeMode ?? this.themeMode,
+        fontSize: fontSize ?? this.fontSize,
+        fontFamily: fontFamily ?? this.fontFamily,
+        locale: locale ?? this.locale,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'themeMode': themeMode.index,
+        'fontSize': fontSize,
+        'fontFamily': fontFamily,
+        'locale': locale.toLanguageTag(),
+      };
+
+  factory Settings.fromMap(Map<String, dynamic> map) => Settings(
+        themeMode: ThemeMode.values[map['themeMode'] as int],
+        fontSize: (map['fontSize'] as num).toDouble(),
+        fontFamily: map['fontFamily'] as String,
+        locale: Locale.fromSubtags(languageCode: map['locale'] as String),
+      );
+
+  String toJson() => jsonEncode(toMap());
+  factory Settings.fromJson(String source) =>
+      Settings.fromMap(jsonDecode(source) as Map<String, dynamic>);
+}

--- a/lib/providers/reading_list_provider.dart
+++ b/lib/providers/reading_list_provider.dart
@@ -1,21 +1,26 @@
-import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/reading_item.dart';
 import '../services/storage_service.dart';
+import 'storage_provider.dart';
 
-class ReadingListProvider extends ChangeNotifier {
+class ReadingListNotifier extends StateNotifier<List<ReadingItem>> {
   final StorageService storage;
-  ReadingListProvider(this.storage);
-
-  List<ReadingItem> get items => storage.items;
+  ReadingListNotifier(this.storage) : super(storage.items);
 
   Future<void> add(String url, {String? title}) async {
     await storage.addItem(ReadingItem(url: url, title: title));
-    notifyListeners();
+    state = storage.items;
   }
 
   Future<void> import(List<ReadingItem> items) async {
     await storage.importItems(items);
-    notifyListeners();
+    state = storage.items;
   }
 }
+
+final readingListProvider =
+    StateNotifierProvider<ReadingListNotifier, List<ReadingItem>>((ref) {
+  final storage = ref.watch(storageProvider);
+  return ReadingListNotifier(storage);
+});

--- a/lib/providers/reading_list_provider.dart
+++ b/lib/providers/reading_list_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../models/reading_item.dart';
+import '../services/storage_service.dart';
+
+class ReadingListProvider extends ChangeNotifier {
+  final StorageService storage;
+  ReadingListProvider(this.storage);
+
+  List<ReadingItem> get items => storage.items;
+
+  Future<void> add(String url, {String? title}) async {
+    await storage.addItem(ReadingItem(url: url, title: title));
+    notifyListeners();
+  }
+
+  Future<void> import(List<ReadingItem> items) async {
+    await storage.importItems(items);
+    notifyListeners();
+  }
+}

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,19 +1,21 @@
-import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/settings.dart';
 import '../services/storage_service.dart';
+import 'storage_provider.dart';
 
-class SettingsProvider extends ChangeNotifier {
+class SettingsNotifier extends StateNotifier<Settings> {
   final StorageService storage;
-  Settings _settings;
-
-  SettingsProvider(this.storage) : _settings = storage.settings;
-
-  Settings get settings => _settings;
+  SettingsNotifier(this.storage) : super(storage.settings);
 
   Future<void> update(Settings settings) async {
-    _settings = settings;
+    state = settings;
     await storage.updateSettings(settings);
-    notifyListeners();
   }
 }
+
+final settingsProvider =
+    StateNotifierProvider<SettingsNotifier, Settings>((ref) {
+  final storage = ref.watch(storageProvider);
+  return SettingsNotifier(storage);
+});

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import '../models/settings.dart';
+import '../services/storage_service.dart';
+
+class SettingsProvider extends ChangeNotifier {
+  final StorageService storage;
+  Settings _settings;
+
+  SettingsProvider(this.storage) : _settings = storage.settings;
+
+  Settings get settings => _settings;
+
+  Future<void> update(Settings settings) async {
+    _settings = settings;
+    await storage.updateSettings(settings);
+    notifyListeners();
+  }
+}

--- a/lib/providers/storage_provider.dart
+++ b/lib/providers/storage_provider.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/storage_service.dart';
+
+final storageProvider = Provider<StorageService>((ref) => throw UnimplementedError());

--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -54,15 +54,14 @@ class _ArticleScreenState extends ConsumerState<ArticleScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        actions: [
-          IconButton(
-            icon: Icon(_readingMode ? Icons.chrome_reader_mode : Icons.public),
-            onPressed: _toggle,
-          ),
-        ],
-      ),
+      appBar: AppBar(),
       body: WebViewWidget(controller: _controller),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _toggle,
+        child: Icon(
+          _readingMode ? Icons.chrome_reader_mode : Icons.public,
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/article_screen.dart
+++ b/lib/screens/article_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:http/http.dart' as http;
+import 'package:readability/readability.dart';
+import 'package:html/parser.dart' show parse;
+
+import '../providers/settings_provider.dart';
+
+class ArticleScreen extends ConsumerStatefulWidget {
+  final String url;
+  const ArticleScreen({super.key, required this.url});
+
+  @override
+  ConsumerState<ArticleScreen> createState() => _ArticleScreenState();
+}
+
+class _ArticleScreenState extends ConsumerState<ArticleScreen> {
+  late WebViewController _controller;
+  late bool _readingMode;
+
+  @override
+  void initState() {
+    super.initState();
+    _readingMode = ref.read(settingsProvider).readingMode;
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted);
+    _load();
+  }
+
+  Future<void> _load() async {
+    if (_readingMode) {
+      final html = await _fetchReadableHtml(widget.url);
+      await _controller.loadHtmlString(html, baseUrl: widget.url);
+    } else {
+      await _controller.loadRequest(Uri.parse(widget.url));
+    }
+  }
+
+  Future<String> _fetchReadableHtml(String url) async {
+    final res = await http.get(Uri.parse(url));
+    final doc = parse(res.body);
+    final article = Readability(Uri.parse(url), doc).parse();
+    return '<html><head><meta name="viewport" content="width=device-width, initial-scale=1"><title>${article.title}</title></head><body>${article.content}</body></html>';
+  }
+
+  void _toggle() {
+    setState(() {
+      _readingMode = !_readingMode;
+    });
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            icon: Icon(_readingMode ? Icons.chrome_reader_mode : Icons.public),
+            onPressed: _toggle,
+          ),
+        ],
+      ),
+      body: WebViewWidget(controller: _controller),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,21 +3,21 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models/reading_item.dart';
 import '../providers/reading_list_provider.dart';
-import 'package:provider/provider.dart';
+import 'article_screen.dart';
 
-class HomeScreen extends StatefulWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  State<HomeScreen> createState() => _HomeScreenState();
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   void initState() {
     super.initState();
@@ -29,9 +29,7 @@ class _HomeScreenState extends State<HomeScreen> {
     if (value == null) return;
     final uri = Uri.tryParse(value);
     if (uri != null && (uri.hasScheme && uri.host.isNotEmpty)) {
-      final provider =
-          context.read<ReadingListProvider>();
-      provider.add(value);
+      ref.read(readingListProvider.notifier).add(value);
     }
   }
 
@@ -42,7 +40,7 @@ class _HomeScreenState extends State<HomeScreen> {
       final file = File(result.files.single.path!);
       final text = await file.readAsString();
       final items = _parsePocketExport(text);
-      await context.read<ReadingListProvider>().import(items);
+      await ref.read(readingListProvider.notifier).import(items);
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text(loc.importPocket)));
@@ -61,7 +59,7 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context);
-    final items = context.watch<ReadingListProvider>().items;
+    final items = ref.watch(readingListProvider);
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.appTitle),
@@ -93,7 +91,8 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _openUrl(String url) {
-    final uri = Uri.parse(url);
-    launchUrl(uri, mode: LaunchMode.externalApplication);
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => ArticleScreen(url: url)),
+    );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -76,16 +76,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
         ],
       ),
-      body: ListView.builder(
-        itemCount: items.length,
-        itemBuilder: (context, index) {
-          final item = items[index];
-          return ListTile(
-            title: Text(item.title ?? item.url),
-            subtitle: Text(item.url),
-            onTap: () => _openUrl(item.url),
-          );
-        },
+      body: Padding(
+        padding: const EdgeInsets.all(8),
+        child: ListView.separated(
+          itemCount: items.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 8),
+          itemBuilder: (context, index) {
+            final item = items[index];
+            return Card(
+              child: ListTile(
+                title: Text(item.title ?? item.url),
+                subtitle: Text(item.url),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => _openUrl(item.url),
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/reading_item.dart';
+import '../providers/reading_list_provider.dart';
+import 'package:provider/provider.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+    ReceiveSharingIntent.getInitialText().then(_handleShared);
+    ReceiveSharingIntent.getTextStream().listen(_handleShared);
+  }
+
+  void _handleShared(String? value) {
+    if (value == null) return;
+    final uri = Uri.tryParse(value);
+    if (uri != null && (uri.hasScheme && uri.host.isNotEmpty)) {
+      final provider =
+          context.read<ReadingListProvider>();
+      provider.add(value);
+    }
+  }
+
+  Future<void> _importPocket() async {
+    final loc = AppLocalizations.of(context);
+    final result = await FilePicker.platform.pickFiles();
+    if (result != null && result.files.single.path != null) {
+      final file = File(result.files.single.path!);
+      final text = await file.readAsString();
+      final items = _parsePocketExport(text);
+      await context.read<ReadingListProvider>().import(items);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(loc.importPocket)));
+      }
+    }
+  }
+
+  List<ReadingItem> _parsePocketExport(String content) {
+    final regex = RegExp(r'<a href="(.*?)"');
+    return regex
+        .allMatches(content)
+        .map((m) => ReadingItem(url: m.group(1)!))
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    final items = context.watch<ReadingListProvider>().items;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.appTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.file_upload),
+            onPressed: _importPocket,
+            tooltip: loc.importPocket,
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () => Navigator.of(context).pushNamed('/settings'),
+            tooltip: loc.settings,
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return ListTile(
+            title: Text(item.title ?? item.url),
+            subtitle: Text(item.url),
+            onTap: () => _openUrl(item.url),
+          );
+        },
+      ),
+    );
+  }
+
+  void _openUrl(String url) {
+    final uri = Uri.parse(url);
+    launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -49,18 +49,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
           const SizedBox(height: 8),
           Card(
-            child: ListTile(
-              title: Text(loc.theme),
-              trailing: DropdownButton<ThemeMode>(
-                value: _temp.themeMode,
-                onChanged: (mode) =>
-                    setState(() => _temp = _temp.copyWith(themeMode: mode)),
-                items: const [
-                  DropdownMenuItem(value: ThemeMode.system, child: Text('System')),
-                  DropdownMenuItem(value: ThemeMode.light, child: Text('Light')),
-                  DropdownMenuItem(value: ThemeMode.dark, child: Text('Dark')),
-                ],
-              ),
+            child: SwitchListTile.adaptive(
+              title: Text(loc.darkMode),
+              value: _temp.themeMode == ThemeMode.dark,
+              onChanged: (v) => setState(() =>
+                  _temp = _temp.copyWith(themeMode: v ? ThemeMode.dark : ThemeMode.light)),
             ),
           ),
           const SizedBox(height: 8),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -30,50 +30,70 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          Row(
-            children: [
-              Text(loc.fontSize),
-              Expanded(
-                child: Slider(
-                  min: 12,
-                  max: 24,
-                  value: _temp.fontSize,
-                  onChanged: (v) => setState(() => _temp = _temp.copyWith(fontSize: v)),
-                ),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                children: [
+                  Expanded(child: Text(loc.fontSize)),
+                  Slider(
+                    min: 12,
+                    max: 24,
+                    value: _temp.fontSize,
+                    onChanged: (v) =>
+                        setState(() => _temp = _temp.copyWith(fontSize: v)),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
-          DropdownButton<ThemeMode>(
-            value: _temp.themeMode,
-            onChanged: (mode) => setState(() => _temp = _temp.copyWith(themeMode: mode)),
-            items: const [
-              DropdownMenuItem(value: ThemeMode.system, child: Text('System')),
-              DropdownMenuItem(value: ThemeMode.light, child: Text('Light')),
-              DropdownMenuItem(value: ThemeMode.dark, child: Text('Dark')),
-            ],
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
+              title: Text(loc.theme),
+              trailing: DropdownButton<ThemeMode>(
+                value: _temp.themeMode,
+                onChanged: (mode) =>
+                    setState(() => _temp = _temp.copyWith(themeMode: mode)),
+                items: const [
+                  DropdownMenuItem(value: ThemeMode.system, child: Text('System')),
+                  DropdownMenuItem(value: ThemeMode.light, child: Text('Light')),
+                  DropdownMenuItem(value: ThemeMode.dark, child: Text('Dark')),
+                ],
+              ),
+            ),
           ),
-          DropdownButton<Locale>(
-            value: _temp.locale,
-            onChanged: (l) => setState(() => _temp = _temp.copyWith(locale: l)),
-            items: const [
-              DropdownMenuItem(value: Locale('en'), child: Text('English')),
-              DropdownMenuItem(value: Locale('zh'), child: Text('中文')),
-              DropdownMenuItem(value: Locale('ja'), child: Text('日本語')),
-            ],
+          const SizedBox(height: 8),
+          Card(
+            child: ListTile(
+              title: Text(loc.language),
+              trailing: DropdownButton<Locale>(
+                value: _temp.locale,
+                onChanged: (l) => setState(() => _temp = _temp.copyWith(locale: l)),
+                items: const [
+                  DropdownMenuItem(value: Locale('en'), child: Text('English')),
+                  DropdownMenuItem(value: Locale('zh'), child: Text('中文')),
+                  DropdownMenuItem(value: Locale('ja'), child: Text('日本語')),
+                ],
+              ),
+            ),
           ),
-          SwitchListTile(
-            title: Text(loc.readingMode),
-            value: _temp.readingMode,
-            onChanged: (v) =>
-                setState(() => _temp = _temp.copyWith(readingMode: v)),
+          const SizedBox(height: 8),
+          Card(
+            child: SwitchListTile.adaptive(
+              title: Text(loc.readingMode),
+              value: _temp.readingMode,
+              onChanged: (v) =>
+                  setState(() => _temp = _temp.copyWith(readingMode: v)),
+            ),
           ),
           const SizedBox(height: 20),
-          ElevatedButton(
+          FilledButton(
             onPressed: () {
               ref.read(settingsProvider.notifier).update(_temp);
               Navigator.of(context).pop();
             },
-            child: Text('OK'),
+            child: Text(loc.ok),
           ),
         ],
       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,24 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../l10n/app_localizations.dart';
 import '../models/settings.dart';
 import '../providers/settings_provider.dart';
 
-class SettingsScreen extends StatefulWidget {
+class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
 
   @override
-  State<SettingsScreen> createState() => _SettingsScreenState();
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-class _SettingsScreenState extends State<SettingsScreen> {
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   late Settings _temp;
 
   @override
   void initState() {
     super.initState();
-    final settings = context.read<SettingsProvider>().settings;
+    final settings = ref.read(settingsProvider);
     _temp = settings;
   }
 
@@ -61,10 +61,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
               DropdownMenuItem(value: Locale('ja'), child: Text('日本語')),
             ],
           ),
+          SwitchListTile(
+            title: Text(loc.readingMode),
+            value: _temp.readingMode,
+            onChanged: (v) =>
+                setState(() => _temp = _temp.copyWith(readingMode: v)),
+          ),
           const SizedBox(height: 20),
           ElevatedButton(
             onPressed: () {
-              context.read<SettingsProvider>().update(_temp);
+              ref.read(settingsProvider.notifier).update(_temp);
               Navigator.of(context).pop();
             },
             child: Text('OK'),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../l10n/app_localizations.dart';
+import '../models/settings.dart';
+import '../providers/settings_provider.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  late Settings _temp;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = context.read<SettingsProvider>().settings;
+    _temp = settings;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(loc.settings)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Row(
+            children: [
+              Text(loc.fontSize),
+              Expanded(
+                child: Slider(
+                  min: 12,
+                  max: 24,
+                  value: _temp.fontSize,
+                  onChanged: (v) => setState(() => _temp = _temp.copyWith(fontSize: v)),
+                ),
+              ),
+            ],
+          ),
+          DropdownButton<ThemeMode>(
+            value: _temp.themeMode,
+            onChanged: (mode) => setState(() => _temp = _temp.copyWith(themeMode: mode)),
+            items: const [
+              DropdownMenuItem(value: ThemeMode.system, child: Text('System')),
+              DropdownMenuItem(value: ThemeMode.light, child: Text('Light')),
+              DropdownMenuItem(value: ThemeMode.dark, child: Text('Dark')),
+            ],
+          ),
+          DropdownButton<Locale>(
+            value: _temp.locale,
+            onChanged: (l) => setState(() => _temp = _temp.copyWith(locale: l)),
+            items: const [
+              DropdownMenuItem(value: Locale('en'), child: Text('English')),
+              DropdownMenuItem(value: Locale('zh'), child: Text('中文')),
+              DropdownMenuItem(value: Locale('ja'), child: Text('日本語')),
+            ],
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: () {
+              context.read<SettingsProvider>().update(_temp);
+              Navigator.of(context).pop();
+            },
+            child: Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/memory_storage_service.dart
+++ b/lib/services/memory_storage_service.dart
@@ -1,0 +1,30 @@
+import '../models/reading_item.dart';
+import '../models/settings.dart';
+import 'storage_service.dart';
+
+/// In-memory implementation used for tests.
+class MemoryStorageService implements StorageService {
+  final List<ReadingItem> _items = [];
+  Settings _settings = Settings();
+
+  @override
+  List<ReadingItem> get items => List.unmodifiable(_items);
+
+  @override
+  Settings get settings => _settings;
+
+  @override
+  Future<void> addItem(ReadingItem item) async {
+    _items.add(item);
+  }
+
+  @override
+  Future<void> importItems(List<ReadingItem> items) async {
+    _items.addAll(items);
+  }
+
+  @override
+  Future<void> updateSettings(Settings settings) async {
+    _settings = settings;
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:icloud_storage/icloud_storage.dart';
+
+import '../models/reading_item.dart';
+import '../models/settings.dart';
+
+class StorageService {
+  static const _itemsBox = 'itemsBox';
+  static const _settingsBox = 'settingsBox';
+  static const _icloudContainer = 'iCloud.com.example.readlyit';
+  static const _icloudFile = 'items.json';
+
+  late final Box _items;
+  late final Box _settings;
+
+  StorageService._();
+
+  static Future<StorageService> create() async {
+    if (!kIsWeb) {
+      Directory dir = await getApplicationDocumentsDirectory();
+      await Hive.initFlutter(dir.path);
+    } else {
+      await Hive.initFlutter();
+    }
+    final service = StorageService._();
+    service._items = await Hive.openBox(_itemsBox);
+    service._settings = await Hive.openBox(_settingsBox);
+    if (!kIsWeb && Platform.isIOS) {
+      await service._downloadFromICloud();
+    }
+    return service;
+  }
+
+  List<ReadingItem> get items =>
+      _items.values.map((e) => ReadingItem.fromMap(Map<String, dynamic>.from(e))).toList();
+
+  Settings get settings => _settings.isNotEmpty
+      ? Settings.fromMap(Map<String, dynamic>.from(_settings.get('settings')))
+      : Settings();
+
+  Future<void> addItem(ReadingItem item) async {
+    await _items.add(item.toMap());
+    await _syncToICloud();
+  }
+
+  Future<void> importItems(List<ReadingItem> items) async {
+    for (final item in items) {
+      await _items.add(item.toMap());
+    }
+    await _syncToICloud();
+  }
+
+  Future<void> updateSettings(Settings settings) async {
+    await _settings.put('settings', settings.toMap());
+  }
+
+  Future<void> _syncToICloud() async {
+    if (!kIsWeb && Platform.isIOS) {
+      final file = await _localFile();
+      await file.writeAsString(jsonEncode(_items.toMap()));
+      await ICloudStorage.upload(
+        containerId: _icloudContainer,
+        filePath: file.path,
+        destinationRelativePath: _icloudFile,
+      );
+    }
+  }
+
+  Future<void> _downloadFromICloud() async {
+    try {
+      final file = await _localFile();
+      await ICloudStorage.download(
+        containerId: _icloudContainer,
+        relativePath: _icloudFile,
+        destinationFilePath: file.path,
+      );
+      final map = jsonDecode(await file.readAsString()) as Map;
+      await _items.clear();
+      for (final e in map.values) {
+        await _items.add(e);
+      }
+    } catch (_) {
+      // ignore errors if file doesn't exist
+    }
+  }
+
+  Future<File> _localFile() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File('${dir.path}/$_icloudFile');
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -10,7 +10,18 @@ import 'package:icloud_storage/icloud_storage.dart';
 import '../models/reading_item.dart';
 import '../models/settings.dart';
 
-class StorageService {
+/// Abstraction for persisting reading items and app settings.
+abstract class StorageService {
+  List<ReadingItem> get items;
+  Settings get settings;
+
+  Future<void> addItem(ReadingItem item);
+  Future<void> importItems(List<ReadingItem> items);
+  Future<void> updateSettings(Settings settings);
+}
+
+/// Hive based implementation with optional iCloud sync on iOS.
+class HiveStorageService implements StorageService {
   static const _itemsBox = 'itemsBox';
   static const _settingsBox = 'settingsBox';
   static const _icloudContainer = 'iCloud.com.example.readlyit';
@@ -19,16 +30,16 @@ class StorageService {
   late final Box _items;
   late final Box _settings;
 
-  StorageService._();
+  HiveStorageService._();
 
-  static Future<StorageService> create() async {
+  static Future<HiveStorageService> create() async {
     if (!kIsWeb) {
       Directory dir = await getApplicationDocumentsDirectory();
       await Hive.initFlutter(dir.path);
     } else {
       await Hive.initFlutter();
     }
-    final service = StorageService._();
+    final service = HiveStorageService._();
     service._items = await Hive.openBox(_itemsBox);
     service._settings = await Hive.openBox(_settingsBox);
     if (!kIsWeb && Platform.isIOS) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,17 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-
+  provider: ^6.1.5
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  file_picker: ^10.1.9
+  path_provider: ^2.1.5
+  receive_sharing_intent: ^1.8.1
+  share_plus: ^11.0.0
+  icloud_storage: ^2.2.0
+  intl: ^0.20.2
+  url_launcher: ^6.3.1
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  provider: ^6.1.5
+  flutter_riverpod: ^2.5.1
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   file_picker: ^10.1.9
@@ -44,6 +44,9 @@ dependencies:
   icloud_storage: ^2.2.0
   intl: ^0.20.2
   url_launcher: ^6.3.1
+  webview_flutter: ^4.7.0
+  readability: ^0.2.2
+  http: ^1.4.0
   
 dev_dependencies:
   flutter_test:

--- a/test/models/reading_item_test.dart
+++ b/test/models/reading_item_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:readlyit/models/reading_item.dart';
+
+void main() {
+  test('serialize and deserialize', () {
+    final item = ReadingItem(url: 'https://example.com', title: 'Example');
+    final json = item.toJson();
+    final from = ReadingItem.fromJson(json);
+    expect(from.url, item.url);
+    expect(from.title, item.title);
+    expect(from.added.isAtSameMomentAs(item.added), true);
+  });
+}

--- a/test/models/settings_test.dart
+++ b/test/models/settings_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:readlyit/models/settings.dart';
+
+void main() {
+  test('copyWith returns updated values', () {
+    final s = Settings();
+    final updated = s.copyWith(fontSize: 18, locale: const Locale('ja'));
+    expect(updated.fontSize, 18);
+    expect(updated.locale.languageCode, 'ja');
+    expect(updated.themeMode, s.themeMode);
+  });
+
+  test('serialize and deserialize', () {
+    final settings = Settings(
+      themeMode: ThemeMode.dark,
+      fontSize: 16,
+      fontFamily: 'Roboto',
+      locale: const Locale('zh'),
+      readingMode: true,
+    );
+    final json = settings.toJson();
+    final from = Settings.fromJson(json);
+    expect(from.themeMode, settings.themeMode);
+    expect(from.fontSize, settings.fontSize);
+    expect(from.fontFamily, settings.fontFamily);
+    expect(from.locale, settings.locale);
+    expect(from.readingMode, settings.readingMode);
+  });
+}

--- a/test/providers/reading_list_provider_test.dart
+++ b/test/providers/reading_list_provider_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:readlyit/models/reading_item.dart';
+import 'package:readlyit/providers/reading_list_provider.dart';
+import 'package:readlyit/providers/storage_provider.dart';
+import 'package:readlyit/services/memory_storage_service.dart';
+
+void main() {
+  test('adds and imports items', () async {
+    final container = ProviderContainer(overrides: [
+      storageProvider.overrideWithValue(MemoryStorageService()),
+    ]);
+
+    final notifier = container.read(readingListProvider.notifier);
+
+    await notifier.add('https://example.com');
+    expect(container.read(readingListProvider).length, 1);
+
+    await notifier.import([ReadingItem(url: 'https://foo')]);
+    expect(container.read(readingListProvider).length, 2);
+  });
+}

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:readlyit/models/settings.dart';
+import 'package:flutter/material.dart';
 import 'package:readlyit/providers/settings_provider.dart';
 import 'package:readlyit/providers/storage_provider.dart';
 import 'package:readlyit/services/memory_storage_service.dart';
@@ -12,7 +13,9 @@ void main() {
     ]);
 
     final notifier = container.read(settingsProvider.notifier);
-    await notifier.update(const Settings(fontSize: 20));
-    expect(container.read(settingsProvider).fontSize, 20);
+    await notifier.update(const Settings(fontSize: 20, themeMode: ThemeMode.dark));
+    final state = container.read(settingsProvider);
+    expect(state.fontSize, 20);
+    expect(state.themeMode, ThemeMode.dark);
   });
 }

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:readlyit/models/settings.dart';
+import 'package:readlyit/providers/settings_provider.dart';
+import 'package:readlyit/providers/storage_provider.dart';
+import 'package:readlyit/services/memory_storage_service.dart';
+
+void main() {
+  test('updates settings', () async {
+    final container = ProviderContainer(overrides: [
+      storageProvider.overrideWithValue(MemoryStorageService()),
+    ]);
+
+    final notifier = container.read(settingsProvider.notifier);
+    await notifier.update(const Settings(fontSize: 20));
+    expect(container.read(settingsProvider).fontSize, 20);
+  });
+}


### PR DESCRIPTION
## Summary
- build basic Flutter app skeleton for ReadlyIt
- add localization and basic settings UI
- implement Hive-based storage with iCloud sync on iOS
- support importing Pocket export files and links from share menu

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840183ccf308333a1512ed7ecbf2037